### PR TITLE
[HOPSWORKS-CLOUD-3083] Bump docker-credential-ecr-login version to 0.6.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@ default['cloud']['init']['config']['unmanaged']            = "false"
 
 default['cloud']['init']['awscli']['url']                  = "#{node['download_url']}/cloud/awscli-exe-linux-x86_64.zip"
 default['cloud']['init']['docker']['config_dir']           = "/root/.docker"
-default['cloud']['init']['docker']['ecr-login']['version'] = "0.4.0"
+default['cloud']['init']['docker']['ecr-login']['version'] = "0.6.0"
 default['cloud']['init']['docker']['ecr-login']['url']     = "#{node['download_url']}/cloud/ecr-login/#{node['cloud']['init']['docker']['ecr-login']['version']}/docker-credential-ecr-login"
 
 default['cloud']['init']['gpu']['driver_url']              = node['nvidia']['driver_url']


### PR DESCRIPTION
Fixes https://github.com/logicalclocks/hopsworks-cloud/issues/3083