### PR TITLE
[CLOUD-249] Bump ec2init version to 0.15

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@ default['cloud']['data_volume']['mount-point']             = "/hopsworks_data"
 default['cloud']['data_volume']['ec2init_checks']          = "#{node['cloud']['data_volume']['root_dir']}/ec2init_checks"
 
 default['cloud']['init']['install_dir']                    = '/root'
-default['cloud']['init']['version']                        = '0.14'
+default['cloud']['init']['version']                        = '0.15'
 
 default['cloud']['init']['config']['hosted_zone']          = "cloud.hopsworks.ai"
 default['cloud']['init']['config']['lets_encrypt_dir']     = "/etc/letsencrypt"


### PR DESCRIPTION
Fixes https://hopsworks.atlassian.net/browse/CLOUD-249

[CLOUD-249]: https://hopsworks.atlassian.net/browse/CLOUD-249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ